### PR TITLE
Upgrade to Java 21, Kotlin 2.1.20, and modernize all dependencies

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,27 +8,28 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
+          distribution: temurin
 
       - name: Grant execute permission for mvnw
         run: chmod +x mvnw
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Cache Maven packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +60,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -68,4 +74,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v3

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar

--- a/hamcrest-matcher-generator-annotationprocessor/pom.xml
+++ b/hamcrest-matcher-generator-annotationprocessor/pom.xml
@@ -78,12 +78,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/hamcrest-matcher-generator-dependencies/pom.xml
+++ b/hamcrest-matcher-generator-dependencies/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/hamcrest-matcher-generator-endtoend-mixed-kotlin-java/pom.xml
+++ b/hamcrest-matcher-generator-endtoend-mixed-kotlin-java/pom.xml
@@ -100,30 +100,26 @@
                                 <sourceDir>${project.basedir}/src/test/java</sourceDir>
                                 <sourceDir>${project.build.directory}/generated-sources/kapt/test</sourceDir>
                                 <sourceDir>${project.build.directory}/generated-sources/kaptKotlin/test</sourceDir>
-                                <sourceDir>${project.build.directory}/generated-test-sources/test-annotations
-                                </sourceDir>
                             </sourceDirs>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.0.0</version>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
-                        <phase>process-test-sources</phase>
+                        <id>add-kapt-test-sources</id>
+                        <phase>generate-test-sources</phase>
                         <goals>
-                            <goal>run</goal>
+                            <goal>add-test-source</goal>
                         </goals>
                         <configuration>
-                            <target>
-                                <move todir="${project.basedir}/target/generated-test-sources/test-annotations"
-                                    force="true">
-                                    <fileset dir="${project.basedir}/target/generated-sources/kapt/test/"/>
-                                </move>
-                            </target>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/kapt/test</source>
+                            </sources>
                         </configuration>
                     </execution>
                 </executions>

--- a/hamcrest-matcher-generator-endtoend-mixed-kotlin-java/pom.xml
+++ b/hamcrest-matcher-generator-endtoend-mixed-kotlin-java/pom.xml
@@ -20,6 +20,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>
@@ -32,7 +37,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <artifactId>kotlin-stdlib</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/hamcrest-matcher-generator-endtoend-plain-java-minimal/pom.xml
+++ b/hamcrest-matcher-generator-endtoend-plain-java-minimal/pom.xml
@@ -35,6 +35,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>

--- a/hamcrest-matcher-generator-endtoend-plain-kotlin/pom.xml
+++ b/hamcrest-matcher-generator-endtoend-plain-kotlin/pom.xml
@@ -20,6 +20,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>
@@ -32,7 +37,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <artifactId>kotlin-stdlib</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/hamcrest-matcher-generator-endtoend-plain-kotlin/pom.xml
+++ b/hamcrest-matcher-generator-endtoend-plain-kotlin/pom.xml
@@ -88,30 +88,26 @@
                                 <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
                                 <sourceDir>${project.build.directory}/generated-sources/kapt/test</sourceDir>
                                 <sourceDir>${project.build.directory}/generated-sources/kaptKotlin/test</sourceDir>
-                                <sourceDir>${project.build.directory}/generated-test-sources/test-annotations
-                                </sourceDir>
                             </sourceDirs>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.0.0</version>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
-                        <phase>process-test-sources</phase>
+                        <id>add-kapt-test-sources</id>
+                        <phase>generate-test-sources</phase>
                         <goals>
-                            <goal>run</goal>
+                            <goal>add-test-source</goal>
                         </goals>
                         <configuration>
-                            <target>
-                                <move todir="${project.basedir}/target/generated-test-sources/test-annotations"
-                                    force="true">
-                                    <fileset dir="${project.basedir}/target/generated-sources/kapt/test/"/>
-                                </move>
-                            </target>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/kapt/test</source>
+                            </sources>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
+        <kotlin.compiler.jvmTarget>21</kotlin.compiler.jvmTarget>
 
         <!-- Sonar -->
         <sonar.organization>marmer-github</sonar.organization>
@@ -59,8 +59,9 @@
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 
         <!-- Plugin and dependency Versions-->
-        <kotlin.version>1.5.10</kotlin.version>
-        <mockito.version>3.11.1</mockito.version>
+        <kotlin.version>2.1.20</kotlin.version>
+        <mockito.version>5.17.0</mockito.version>
+        <argLine></argLine>
     </properties>
 
     <repositories>
@@ -68,21 +69,11 @@
             <id>mavenCentral</id>
             <url>https://repo1.maven.org/maven2/</url>
         </repository>
-        <repository>
-            <id>jcenter</id>
-            <name>JCenter</name>
-            <url>https://jcenter.bintray.com/</url>
-        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>mavenCentral</id>
             <url>https://repo1.maven.org/maven2/</url>
-        </pluginRepository>
-        <pluginRepository>
-            <id>jcenter</id>
-            <name>JCenter</name>
-            <url>https://jcenter.bintray.com/</url>
         </pluginRepository>
     </pluginRepositories>
 
@@ -114,11 +105,11 @@
             <dependency>
                 <groupId>com.google.auto.service</groupId>
                 <artifactId>auto-service</artifactId>
-                <version>1.0</version>
+                <version>1.1.1</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-jdk8</artifactId>
+                <artifactId>kotlin-stdlib</artifactId>
                 <version>${kotlin.version}</version>
             </dependency>
             <dependency>
@@ -134,17 +125,12 @@
             <dependency>
                 <groupId>io.github.classgraph</groupId>
                 <artifactId>classgraph</artifactId>
-                <version>4.8.108</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.annotation</groupId>
-                <artifactId>javax.annotation-api</artifactId>
-                <version>1.3.2</version>
+                <version>4.8.179</version>
             </dependency>
             <dependency>
                 <groupId>io.github.glytching</groupId>
                 <artifactId>junit-extensions</artifactId>
-                <version>2.3.0</version>
+                <version>2.6.0</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
@@ -154,18 +140,18 @@
             <dependency>
                 <groupId>com.google.testing.compile</groupId>
                 <artifactId>compile-testing</artifactId>
-                <version>0.19</version>
+                <version>0.21.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.google.truth</groupId>
                 <artifactId>truth</artifactId>
-                <version>1.1.3</version>
+                <version>1.4.4</version>
             </dependency>
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.20</version>
+                <version>1.18.36</version>
             </dependency>
             <dependency>
                 <groupId>com.github.javaparser</groupId>
@@ -185,14 +171,21 @@
             <dependency>
                 <groupId>org.mockito.kotlin</groupId>
                 <artifactId>mockito-kotlin</artifactId>
-                <version>3.2.0</version>
+                <version>5.4.0</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>
-                <version>5.7.2</version>
+                <version>5.12.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>1.12.2</version>
+                <scope>test</scope>
             </dependency>
 
         </dependencies>
@@ -204,17 +197,23 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
+                    <version>3.1.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.5.2</version>
+                    <configuration>
+                        <argLine>@{argLine} --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.5.2</version>
+                    <configuration>
+                        <argLine>@{argLine} --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</argLine>
+                    </configuration>
                     <executions>
                         <execution>
                             <goals>
@@ -227,7 +226,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.7</version>
+                    <version>0.8.13</version>
                     <configuration>
                         <append>true</append>
                     </configuration>
@@ -235,33 +234,33 @@
                 <plugin>
                     <groupId>org.sonarsource.scanner.maven</groupId>
                     <artifactId>sonar-maven-plugin</artifactId>
-                    <version>3.9.0.2155</version>
+                    <version>4.0.0.4121</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.2.7</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.11.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.8</version>
+                    <version>1.7.0</version>
                     <extensions>true</extensions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.13.0</version>
                     <executions>
                         <!-- Replacing default-compile as it is treated specially by maven -->
                         <execution>
@@ -336,7 +335,7 @@
                 <plugin>
                     <groupId>org.jetbrains.dokka</groupId>
                     <artifactId>dokka-maven-plugin</artifactId>
-                    <version>1.4.32</version>
+                    <version>2.0.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
- Java JVM target: 11 → 21
- Kotlin: 1.5.10 → 2.1.20 (kotlin-stdlib-jdk8 → kotlin-stdlib)
- JUnit Jupiter: 5.7.2 → 5.12.2 + add junit-platform-launcher 1.12.2 (required since JUnit 5.10)
- Mockito: 3.11.1 → 5.17.0, mockito-kotlin: 3.2.0 → 5.4.0
- Lombok: 1.18.20 → 1.18.36 (Java 21 support)
- compile-testing: 0.19 → 0.21.0
- ClassGraph: 4.8.108 → 4.8.179
- Google Truth: 1.1.3 → 1.4.4, Auto Service: 1.0 → 1.1.1
- Dokka: 1.4.32 → 2.0.0 (Kotlin 2.x compatible)
- maven-compiler-plugin: 3.8.1 → 3.13.0
- maven-surefire-plugin + maven-failsafe-plugin: 2.22.2 → 3.5.2
- jacoco-maven-plugin: 0.8.7 → 0.8.13
- sonar-maven-plugin: 3.9.0.2155 → 4.0.0.4121
- Various other plugin updates (gpg, source, javadoc, nexus-staging, deploy)
- Remove javax.annotation-api (provided by JDK since Java 9)
- Remove defunct JCenter repositories
- Add --add-opens JVM flags for compile-testing on Java 9+ (using @{argLine} for JaCoCo compat)
- Maven wrapper: 3.6.3 → 3.9.9
- CI: actions updated to v4, Java 11 → 21 with Temurin distribution
- CodeQL: action versions v1 → v3, add JDK 21 setup step

https://claude.ai/code/session_01MmXP1tsLB6stSykdKE2Zji