### PR TITLE
Upgrade to Kotlin 2.0.20, Java 21, and modern dependency/plugin versions

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/hamcrest-matcher-generator-annotationprocessor/pom.xml
+++ b/hamcrest-matcher-generator-annotationprocessor/pom.xml
@@ -90,6 +90,11 @@
             <artifactId>kotlin-test-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -109,6 +114,20 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        --add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+                        --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+                        --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+                        --add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+                        --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+                        --add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+                        --add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+                        --add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+                        --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+                        --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+                    </argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/hamcrest-matcher-generator-endtoend-mixed-kotlin-java/pom.xml
+++ b/hamcrest-matcher-generator-endtoend-mixed-kotlin-java/pom.xml
@@ -95,30 +95,25 @@
                                 <sourceDir>${project.basedir}/src/test/java</sourceDir>
                                 <sourceDir>${project.build.directory}/generated-sources/kapt/test</sourceDir>
                                 <sourceDir>${project.build.directory}/generated-sources/kaptKotlin/test</sourceDir>
-                                <sourceDir>${project.build.directory}/generated-test-sources/test-annotations
-                                </sourceDir>
                             </sourceDirs>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.0.0</version>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>add-kapt-test-sources</id>
                         <phase>process-test-sources</phase>
                         <goals>
-                            <goal>run</goal>
+                            <goal>add-test-source</goal>
                         </goals>
                         <configuration>
-                            <target>
-                                <move todir="${project.basedir}/target/generated-test-sources/test-annotations"
-                                    force="true">
-                                    <fileset dir="${project.basedir}/target/generated-sources/kapt/test/"/>
-                                </move>
-                            </target>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/kapt/test</source>
+                            </sources>
                         </configuration>
                     </execution>
                 </executions>

--- a/hamcrest-matcher-generator-endtoend-plain-kotlin/pom.xml
+++ b/hamcrest-matcher-generator-endtoend-plain-kotlin/pom.xml
@@ -83,30 +83,25 @@
                                 <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
                                 <sourceDir>${project.build.directory}/generated-sources/kapt/test</sourceDir>
                                 <sourceDir>${project.build.directory}/generated-sources/kaptKotlin/test</sourceDir>
-                                <sourceDir>${project.build.directory}/generated-test-sources/test-annotations
-                                </sourceDir>
                             </sourceDirs>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.0.0</version>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>add-kapt-test-sources</id>
                         <phase>process-test-sources</phase>
                         <goals>
-                            <goal>run</goal>
+                            <goal>add-test-source</goal>
                         </goals>
                         <configuration>
-                            <target>
-                                <move todir="${project.basedir}/target/generated-test-sources/test-annotations"
-                                    force="true">
-                                    <fileset dir="${project.basedir}/target/generated-sources/kapt/test/"/>
-                                </move>
-                            </target>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/kapt/test</source>
+                            </sources>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 
         <!-- Plugin and dependency Versions-->
-        <kotlin.version>1.5.10</kotlin.version>
-        <mockito.version>3.11.1</mockito.version>
+        <kotlin.version>2.0.20</kotlin.version>
+        <mockito.version>5.11.0</mockito.version>
     </properties>
 
     <repositories>
@@ -68,21 +68,11 @@
             <id>mavenCentral</id>
             <url>https://repo1.maven.org/maven2/</url>
         </repository>
-        <repository>
-            <id>jcenter</id>
-            <name>JCenter</name>
-            <url>https://jcenter.bintray.com/</url>
-        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>mavenCentral</id>
             <url>https://repo1.maven.org/maven2/</url>
-        </pluginRepository>
-        <pluginRepository>
-            <id>jcenter</id>
-            <name>JCenter</name>
-            <url>https://jcenter.bintray.com/</url>
         </pluginRepository>
     </pluginRepositories>
 
@@ -114,7 +104,7 @@
             <dependency>
                 <groupId>com.google.auto.service</groupId>
                 <artifactId>auto-service</artifactId>
-                <version>1.0</version>
+                <version>1.1.1</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
@@ -134,7 +124,7 @@
             <dependency>
                 <groupId>io.github.classgraph</groupId>
                 <artifactId>classgraph</artifactId>
-                <version>4.8.108</version>
+                <version>4.8.177</version>
             </dependency>
             <dependency>
                 <groupId>javax.annotation</groupId>
@@ -154,23 +144,23 @@
             <dependency>
                 <groupId>com.google.testing.compile</groupId>
                 <artifactId>compile-testing</artifactId>
-                <version>0.19</version>
+                <version>0.21.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.google.truth</groupId>
                 <artifactId>truth</artifactId>
-                <version>1.1.3</version>
+                <version>1.4.2</version>
             </dependency>
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.20</version>
+                <version>1.18.34</version>
             </dependency>
             <dependency>
                 <groupId>com.github.javaparser</groupId>
                 <artifactId>javaparser-core</artifactId>
-                <version>3.2.12</version>
+                <version>3.25.10</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
@@ -185,18 +175,33 @@
             <dependency>
                 <groupId>org.mockito.kotlin</groupId>
                 <artifactId>mockito-kotlin</artifactId>
-                <version>3.2.0</version>
+                <version>5.4.0</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>
-                <version>5.7.2</version>
+                <version>5.12.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>1.12.1</version>
+                <scope>test</scope>
             </dependency>
 
         </dependencies>
     </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <pluginManagement>
@@ -209,12 +214,19 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.5.2</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.junit.platform</groupId>
+                            <artifactId>junit-platform-launcher</artifactId>
+                            <version>1.12.1</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.22.2</version>
+                    <version>3.5.2</version>
                     <executions>
                         <execution>
                             <goals>
@@ -223,11 +235,23 @@
                             </goals>
                         </execution>
                     </executions>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.junit.platform</groupId>
+                            <artifactId>junit-platform-launcher</artifactId>
+                            <version>1.12.1</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.6.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.7</version>
+                    <version>0.8.12</version>
                     <configuration>
                         <append>true</append>
                     </configuration>
@@ -261,7 +285,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.13.0</version>
                     <executions>
                         <!-- Replacing default-compile as it is treated specially by maven -->
                         <execution>


### PR DESCRIPTION
## Summary

- **Kotlin 2.0.20** (K2 compiler / KSP compat layer via KAPT on K2), up from 1.5.10
- **Maven 3.9.9** wrapper, up from 3.6.3; removed deprecated JCenter repositories
- **All core dependencies and plugins modernised** to current stable versions (see details below)
- **Replaced `maven-antrun` file-move hack** in both Kotlin end-to-end modules with `build-helper-maven-plugin:add-test-source`, as required by the CLAUDE.md known-pitfalls section
- **Added `--add-opens` for `jdk.compiler`** in Failsafe argLine so `compile-testing` works on Java 21
- **Added `junit-platform-launcher:1.12.1`** to the root POM's test dependencies to prevent version misalignment with Surefire 3.5.2

### Version changes

| Artifact | Before | After |
|---|---|---|
| `kotlin.version` | 1.5.10 | 2.0.20 |
| `mockito-core` | 3.11.1 | 5.11.0 |
| `mockito-kotlin` | 3.2.0 | 5.4.0 |
| `junit-jupiter` | 5.7.2 | 5.12.1 |
| `junit-platform-launcher` | — | 1.12.1 |
| `lombok` | 1.18.20 | 1.18.34 |
| `auto-service` | 1.0 | 1.1.1 |
| `classgraph` | 4.8.108 | 4.8.177 |
| `truth` | 1.1.3 | 1.4.2 |
| `compile-testing` | 0.19 | 0.21.0 |
| `javaparser-core` | 3.2.12 | 3.25.10 |
| `maven-compiler-plugin` | 3.8.1 | 3.13.0 |
| `maven-surefire-plugin` | 2.22.2 | 3.5.2 |
| `maven-failsafe-plugin` | 2.22.2 | 3.5.2 |
| `jacoco-maven-plugin` | 0.8.7 | 0.8.12 |
| Maven wrapper | 3.6.3 | 3.9.9 |

Note: `kotlin.compiler.jvmTarget` remains at `11` to avoid breaking library consumers.

## Test plan

- [x] `./mvnw clean install` — all 6 modules build green (unit tests pass)
- [x] `./mvnw clean verify` — all 6 modules pass including 23 integration tests in `MatcherGenerationProcessorIT`
- [x] Both Kotlin end-to-end modules generate and compile matchers correctly via KAPT + build-helper (no antrun file moving)

https://claude.ai/code/session_01Arp7X8qVAZaTAu4kD6vDp1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Arp7X8qVAZaTAu4kD6vDp1)_