### PR TITLE
Fix SonarCloud coverage badge not showing coverage data

### DIFF
--- a/hamcrest-matcher-generator-annotationprocessor/pom.xml
+++ b/hamcrest-matcher-generator-annotationprocessor/pom.xml
@@ -116,6 +116,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <argLine>
+                        ${argLine}
                         --add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
                         --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
                         --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/hamcrest-matcher-generator-annotationprocessor/pom.xml
+++ b/hamcrest-matcher-generator-annotationprocessor/pom.xml
@@ -116,7 +116,7 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <argLine>
-                        ${argLine}
+                        @{argLine}
                         --add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
                         --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
                         --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,9 @@
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
         <sonar.kotlin.coveragePlugin>jacoco</sonar.kotlin.coveragePlugin>
         <sonar.coverage.jacoco.xmlReportPaths>
-            */target/site/jacoco/jacoco.xml,*/target/site/jacoco-it/jacoco.xml
+            ${project.basedir}/target/site/jacoco/jacoco.xml,${project.basedir}/target/site/jacoco-it/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
+        <argLine/>
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 
         <!-- Plugin and dependency Versions-->


### PR DESCRIPTION
## Summary

- Add `${argLine}` to `maven-failsafe-plugin`'s `<argLine>` in `annotationprocessor/pom.xml` so JaCoCo's Java agent is injected into the integration-test JVM
- Add default empty `<argLine/>` property to root pom to prevent unresolved-property errors on local builds that don't run `jacoco:prepare-agent`
- Fix `sonar.coverage.jacoco.xmlReportPaths` — change `*/target/site/jacoco/jacoco.xml` to `${project.basedir}/target/site/jacoco/jacoco.xml` so the path resolves correctly for each module

## Root causes

**No coverage data collected**: All meaningful tests in this project run via `maven-failsafe-plugin` (integration tests). The CI step runs `jacoco:prepare-agent` which injects the JaCoCo agent by setting the `${argLine}` Maven property — but the failsafe `<argLine>` config was hardcoded with only `--add-opens` flags and never referenced `${argLine}`, so the JaCoCo agent was never loaded into the IT JVM. Result: empty/missing `jacoco.exec`, SonarCloud sees 0 coverage.

**Wrong report path**: `sonar.coverage.jacoco.xmlReportPaths` was set to `*/target/site/jacoco/jacoco.xml`. When SonarCloud resolves this relative to each module's basedir, the `*` glob looks for a subdirectory *inside* the module dir (e.g. `annotationprocessor/[something]/target/...`), which never exists. Changing to `${project.basedir}/target/site/jacoco/jacoco.xml` resolves correctly to each module's own report.

## Test plan

- [ ] Push triggers CI-Build workflow
- [ ] After CI succeeds, SonarCloud coverage badge on README should show a percentage instead of "unknown"

https://claude.ai/code/session_01RVq6GSz8i7wyyKew7PbuaQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVq6GSz8i7wyyKew7PbuaQ)_